### PR TITLE
use app.add_css_file to correct css handling under subdirectory docs

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,8 +1,7 @@
 {%- extends "!layout.html" %}
 {%- block extrahead %}
-{{ super() }}
-    <link rel="stylesheet" href="_static/trans-tooltip.css" />
-{% if IS_READTHEDOCS %}
+  {{ super() }}
+  {% if IS_READTHEDOCS %}
     <meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}" />
-{% endif %}
+  {% endif %}
 {% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -150,12 +150,13 @@ def setup(app):
     app.connect('builder-inited', show_builder_name)
 
     # for original text tooltip support
-    def add_transform(event_app):
+    def setup_html_biulder_extras(event_app):
         if isinstance(event_app.builder, StandaloneHTMLBuilder):
             app.add_transform(CopyLocaleOriginalMessageAsAttribute)
             app.add_transform(AddClassAttributeToLocaleTranslatedNode)
             app.add_transform(AppendLocaleOriginalMessage)
-    app.connect('builder-inited', add_transform)
+            app.add_css_file("trans-tooltip.css")
+    app.connect('builder-inited', setup_html_biulder_extras)
 
     setup_original(app)
 


### PR DESCRIPTION
fix defect of mishandling css link in the docs under subdirectories
* use app.add_css_file
* remove css link in _template/layout.html