### PR TITLE
Use sphinxcontrib-trimblank

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -24,11 +24,19 @@ html_context['IS_READTHEDOCS'] = os.environ.get("READTHEDOCS", False)
 html_context['GOOGLE_SITE_VERIFICATION'] = os.environ.get('GOOGLE_SITE_VERIFICATION', "")
 
 
-# support for tooltip showing original text ----------------------------
+# support for tooltip showing original text, etc -----------------------
 extensions = globals().get("extensions", [])
 #extensions.append("sphinxext.showorig")
 extensions.append("sphinxext.hoverorig")
-extensions.append("readthedocs_ext.readthedocs")
+extensions.append("readthedocs_ext.readthedocs") # to locally test rtd build
+extensions.append("sphinxcontrib.trimblank") # trim unnatural spaces in CJK
+
+# see, https://github.com/amedama41/sphinxcontrib-trimblank
+trimblank_enabled = True
+trimblank_keep_alnum_blank = False
+trimblank_keep_blank_before = r"[\s(]"
+trimblank_keep_blank_after = r"[\s),.:?]"
+trimblank_debug = False
 
 setup_original = setup  # from 'flask/docs/conf.py'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -e ./flask[docs]
 sphinx-intl
+sphinxcontrib-trimblank
 readthedocs-sphinx-ext
 invoke
 git+https://github.com/msiz07/sphinx-hoverorig.git@main


### PR DESCRIPTION
Introduce sphinxcontrib-trimblank to trim unnatural spaces in CJK document generated by sphinx.